### PR TITLE
change order for Emeral

### DIFF
--- a/expansions/script/c24003014.lua
+++ b/expansions/script/c24003014.lua
@@ -14,10 +14,10 @@ end
 function scard.tsop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,DM_HINTMSG_TOSHIELD)
 	local g1=Duel.SelectMatchingCard(tp,Card.IsAbleToShield,tp,LOCATION_HAND,0,1,1,nil)
-	if g1:GetCount()==0 or not Duel.SendtoShield(g1,tp) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,DM_HINTMSG_ATOHAND)
 	local g2=Duel.SelectMatchingCard(tp,dm.ShieldZoneFilter(scard.thfilter),tp,DM_LOCATION_SHIELD,0,1,1,nil,e)
 	if g2:GetCount()==0 then return end
 	Duel.SetTargetCard(g2)
 	Duel.SendtoHand(g2,PLAYER_OWNER,REASON_EFFECT)
+	if g1:GetCount()==0 or not Duel.SendtoShield(g1,tp) then return end
 end


### PR DESCRIPTION
Requires fix for Issue #18 to be implemented. (If not, the game disconnects both  players if Emeral is activated with no shields available). 
EDIT: Changing OCGCORE to Fluoro makes it no longer crash on 0 cards. 
![image](https://user-images.githubusercontent.com/37833135/56031897-032b8b00-5d21-11e9-9814-d51ee0de5dfb.png)
